### PR TITLE
feat: support vrimg and exr ouput formats to write raw files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,9 @@ venv/
 # macOS
 .DS_STORE
 
+
+# Backup files
+*.bak
+
+# Temp folder
+tmp/

--- a/src/deadline/max_adaptor/MaxClient/render_element_manager.py
+++ b/src/deadline/max_adaptor/MaxClient/render_element_manager.py
@@ -376,9 +376,14 @@ class RenderElementManager:
         """
         Configure V-Ray specific render element settings.
 
+        For raw output formats (.vrimg, .exr), render elements are bundled into a single
+        multichannel file by V-Ray, so individual render element filename configuration
+        is skipped. The raw output path is configured in VrayHandler.start_render().
+
         Args:
             data: Configuration parameters
             render_elements: List of render elements from scene
+            ignore_list: List of render element names to ignore
         """
         try:
             # Check if V-Ray VFB control is enabled

--- a/src/deadline/max_adaptor/MaxClient/render_handlers/vray_handler.py
+++ b/src/deadline/max_adaptor/MaxClient/render_handlers/vray_handler.py
@@ -11,7 +11,11 @@ from typing import Any
 
 from pymxs import runtime as rt
 
-from deadline.max_shared.utilities.max_utils import set_vray_output_path
+from deadline.max_shared.utilities.max_utils import (
+    configure_vray_raw_output,
+    is_vray_raw_output_format,
+    set_vray_output_path,
+)
 
 from .default_max_handler import DefaultMaxHandler
 
@@ -173,14 +177,29 @@ class VrayHandler(DefaultMaxHandler):
         """
         Override to set V-Ray output path before rendering.
 
-        Always sets V-Ray output path for both standard V-Ray and V-Ray RT.
+        Automatically uses raw output pipeline for .vrimg and .exr formats,
+        which stores all render elements in a single multichannel container file.
+        For other formats, uses standard V-Ray split buffer output.
         """
-        # Always set V-Ray output path
         if self.output_dir and self.output_name:
-            set_vray_output_path(
-                output_path=self.output_dir,
-                output_name=self.output_name,
-                output_format=self.output_format or ".exr",
-            )
+            output_format = self.output_format or ".exr"
+
+            # Auto-detect raw output mode based on format
+            if is_vray_raw_output_format(output_format):
+                self.log_to_console(f"V-Ray raw output mode enabled for format: {output_format}")
+                warnings = configure_vray_raw_output(
+                    output_path=self.output_dir,
+                    output_name=self.output_name,
+                    output_format=output_format,
+                )
+                for warning in warnings:
+                    self.log_to_console(f"Warning: {warning}")
+            else:
+                # Standard V-Ray output path for other formats
+                set_vray_output_path(
+                    output_path=self.output_dir,
+                    output_name=self.output_name,
+                    output_format=output_format,
+                )
 
         super().start_render(data)

--- a/src/deadline/max_shared/utilities/max_utils.py
+++ b/src/deadline/max_shared/utilities/max_utils.py
@@ -135,6 +135,38 @@ def _get_vray_rt_settings() -> Optional[Any]:
     return None
 
 
+def _set_vray_property(prop_name: str, value: Any, warnings: list[str]) -> None:
+    """
+    Set a V-Ray property on the appropriate renderer object.
+
+    V-Ray CPU and GPU have different property access patterns:
+    - V-Ray GPU: Properties must be set on vray_rt_settings (nested V_Ray_settings object)
+    - V-Ray CPU: Properties must be set on rt.renderers.current directly
+
+    This function automatically detects the renderer type and sets properties
+    on the correct object, avoiding MAXScript errors from setting on the wrong object.
+
+    :param prop_name: name of the V-Ray property to set
+    :param value: value to set for the property
+    :param warnings: list to append warning messages to
+    """
+    vray_rt_settings = _get_vray_rt_settings()
+
+    try:
+        if vray_rt_settings is not None:
+            # V-Ray GPU - set on vray_rt_settings only
+            setattr(vray_rt_settings, prop_name, value)
+            _logger.debug(f"[_set_vray_property] Set vray_rt_settings.{prop_name} = {value}")
+        # else:
+        # V-Ray CPU - set on rt.renderers.current
+        setattr(rt.renderers.current, prop_name, value)
+        _logger.debug(f"[_set_vray_property] Set rt.renderers.current.{prop_name} = {value}")
+    except Exception as e:
+        warning_msg = f"Failed to set V-Ray property {prop_name}: {e}"
+        _logger.warning(f"[_set_vray_property] {warning_msg}")
+        warnings.append(warning_msg)
+
+
 def get_render_elements() -> list[RenderElementInfo]:
     """
     Gets all render elements present in the max scene with their properties.
@@ -306,22 +338,6 @@ def purify_render_element_name(element_name: str) -> str:
     return purified_name
 
 
-def get_render_element_by_name(element_name: str) -> Optional[RenderElementInfo]:
-    """
-    Gets a specific render element by name.
-
-    :param element_name: name of the render element to find
-    :returns: RenderElementInfo object or None if not found
-    """
-    render_elements: list[RenderElementInfo] = get_render_elements()
-
-    for element in render_elements:
-        if element.name == element_name:
-            return element
-
-    return None
-
-
 def validate_render_element_configuration(
     render_elements: list[RenderElementInfo], settings: RenderElementConfigurationSettings
 ) -> list[str]:
@@ -434,22 +450,347 @@ def set_vray_output_path(
     :raises RuntimeError: if V-Ray output path cannot be set
     """
     split_filepath: str = os.path.join(output_path, f"{output_name}{output_format}")
+    warnings: list[str] = []
+
+    _logger.debug(
+        f"[set_vray_output_path] Attempting to set output_splitfilename = {split_filepath}"
+    )
+    _set_vray_property("output_splitfilename", split_filepath, warnings)
+
+    if warnings:
+        error_msg: str = f"[set_vray_output_path] Failed to set V-Ray output path: {warnings[0]}"
+        _logger.error(error_msg)
+        raise RuntimeError(error_msg)
+
+    _logger.info(f"[set_vray_output_path] V-Ray output path set to: {split_filepath}")
+
+
+def _configure_split_buffer_settings(
+    output_path: Optional[str],
+    output_name: Optional[str],
+    output_file_format: Optional[str],
+    warnings: list[str],
+) -> Optional[str]:
+    """
+    Configure V-Ray split buffer settings for both CPU and GPU renderers.
+
+    This helper function sets up the split buffer flags and filename that are
+    common to both V-Ray VFB and 3dsMax framebuffer modes.
+
+    D10 Pattern:
+    - output_splitgbuffer = True (enable split buffer)
+    - output_splitRGB = True (save RGB channels)
+    - output_splitAlpha = True (save Alpha channel)
+    - output_splitfilename = path (base filename for split files)
+
+    NOTE: output_saveRawFile is for saving raw .vrimg files, NOT for split buffer.
+
+    :param output_path: output directory path for split buffer files
+    :param output_name: base output filename for split buffer files
+    :param output_file_format: output file format/extension
+    :param warnings: list to append warning messages to
+    :returns: the base filepath if successfully configured, None otherwise
+    """
+    # D10: Enable split buffer flag only
+    _set_vray_property("output_splitgbuffer", True, warnings)
+
+    # Enable split RGB to save render elements to separate files
+    # This is required for V-Ray to actually output the render element files
+    _set_vray_property("output_splitRGB", True, warnings)
+    _set_vray_property("output_splitAlpha", True, warnings)
+    # NOTE: output_saveRawFile is for saving raw .vrimg files, NOT for split buffer output
+
+    base_filepath: Optional[str] = None
+
+    # Set the base filename for split files
+    if output_path and output_name:
+        base_name, _ = os.path.splitext(output_name)
+        assert output_file_format is not None  # Should never be None due to default value
+        extension = (
+            output_file_format if output_file_format.startswith(".") else f".{output_file_format}"
+        )
+        base_filepath = os.path.join(output_path, f"{base_name}{extension}")
+
+        _logger.debug(
+            f"[_configure_split_buffer_settings] Setting output_splitfilename "
+            f"via _set_vray_property"
+        )
+        _set_vray_property("output_splitfilename", base_filepath, warnings)
+        _logger.info(
+            f"[_configure_split_buffer_settings] V-Ray split buffer filename set to: "
+            f"{base_filepath}"
+        )
+
+        # Explicitly unset output_splitbitmap to ensure clean state
+        # _set_vray_property("output_splitbitmap", rt.undefined, warnings)
+        # rt.renderers.current.output_splitbitmap = rt.undefined
+        # rt.renderers.current.V_Ray_settings.output_splitbitmap = rt.undefined
+        _logger.info("[_configure_split_buffer_settings] V-Ray output_splitbitmap set to undefined")
+    else:
+        missing_params = []
+        if not output_path:
+            missing_params.append("output_file_path")
+        if not output_name:
+            missing_params.append("output_file_name (check template has this defined)")
+        warnings.append(
+            f"Split buffer enabled but missing: {', '.join(missing_params)} - split files may not save correctly"
+        )
+
+    return base_filepath
+
+
+def _configure_render_element_filenames(
+    render_elements: list[RenderElementInfo],
+    base_filepath: Optional[str],
+    ignore_list: list[str],
+    warnings: list[str],
+) -> None:
+    """
+    Configure filenames for render elements (D10 pattern).
+
+    Sets a UNIQUE output filename for each render element by appending the
+    element name to the base filename. Does NOT modify the element's enabled state.
+
+    D10 Pattern:
+    - Skip ignored elements (by name)
+    - Skip disabled elements (read but don't modify enabled state)
+    - Use SetRenderElementFilename() to set paths with unique names per element
+    - Use SetElementsActive(True) to enable RE output
+    - Does NOT use SetOutputEnabled()
+
+    :param render_elements: list of RenderElementInfo objects
+    :param base_filepath: base filepath for output (e.g., "C:/output/render.png")
+    :param ignore_list: list of render element names to ignore
+    :param warnings: list to append warning messages to
+    """
+    if not base_filepath:
+        warnings.append("Render element filename setup skipped: Missing output path or name")
+        return
 
     try:
-        # Always set for standard V-Ray
-        rt.renderers.current.output_splitfilename = split_filepath
+        re_manager = rt.maxOps.GetCurRenderElementMgr()
+        if not re_manager:
+            warnings.append("Render element filename setup failed: No render element manager")
+            return
 
-        # Also set for V-Ray RT if applicable
-        vray_rt_settings: Optional[Any] = _get_vray_rt_settings()
-        if vray_rt_settings is not None:
-            vray_rt_settings.output_splitfilename = split_filepath
+        # Parse base filepath into components for building unique filenames
+        base_dir = os.path.dirname(base_filepath)
+        base_name_with_ext = os.path.basename(base_filepath)
+        base_name, extension = os.path.splitext(base_name_with_ext)
 
-        _logger.info(f"V-Ray output path set to: {split_filepath}")
+        filename_set_count = 0
+        for element in render_elements:
+            # D10 pattern: Skip ignored elements (by name)
+            if element.name in ignore_list:
+                _logger.debug(f"Skipping ignored render element: {element.name}")
+                continue
+
+            # D10 does NOT skip disabled elements - it sets filenames for ALL elements
+            # Users may enable elements later, and V-Ray VFB needs all paths configured
+
+            try:
+                # Create unique filename per element: basename_elementname.ext
+                purified_name = purify_render_element_name(element.name)
+                unique_filename = f"{base_name}_{purified_name}{extension}"
+                unique_filepath = os.path.join(base_dir, unique_filename)
+
+                re_manager.SetRenderElementFilename(element.index, unique_filepath)
+                # Update in-memory element info for later validation
+                element.output_filename = unique_filepath.replace("\\", "/")
+                element.has_output_path = True
+                filename_set_count += 1
+                _logger.debug(f"Set filename for '{element.name}': {unique_filepath}")
+            except Exception as e:
+                warnings.append(f"Failed to set filename for '{element.name}': {e}")
+
+        # D10: Enable render element output via SetElementsActive(True)
+        # This is CRITICAL - without this, render elements won't be saved to files
+        try:
+            re_manager.SetElementsActive(True)
+            _logger.info("Render element manager: SetElementsActive(True)")
+        except Exception as e:
+            _logger.warning(f"Could not call SetElementsActive: {e}")
+
+        _logger.info(f"Set filenames for {filename_set_count} render elements")
+    except Exception as e:
+        warnings.append(f"Failed to configure render element filenames: {e}")
+
+
+def _configure_per_element_settings(
+    render_elements: list[RenderElementInfo],
+    vfb_control: bool,
+    ignore_list: list[str],
+    warnings: list[str],
+) -> None:
+    """
+    Configure per-element settings for render elements.
+
+    This function handles enabling/disabling render elements based on VFB control
+    and ignore list, and sets the vrayVFB property on each element.
+
+    :param render_elements: list of RenderElementInfo objects
+    :param vfb_control: whether VFB control is enabled
+    :param ignore_list: list of render element names to ignore
+    :param warnings: list to append warning messages to
+    """
+    enabled_count = 0
+    disabled_count = 0
+
+    for element in render_elements:
+        element_obj = element.element_object
+        if not element_obj:
+            continue
+
+        element_name: str = element.name
+        should_ignore = element_name in ignore_list
+
+        # Skip Missing_Render_Element_Plug_in
+        element_type = str(rt.classof(element_obj))
+        if element_type == "Missing_Render_Element_Plug_in":
+            continue
+
+        # Automatically enable/disable render elements based on VFB control and ignore list
+        if vfb_control:
+            try:
+                if should_ignore:
+                    element_obj.enabled = False
+                    element.enabled = False
+                    disabled_count += 1
+                    _logger.info(f"Disabled render element (ignored): {element_name}")
+                else:
+                    element_obj.enabled = True
+                    element.enabled = True
+                    enabled_count += 1
+                    _logger.debug(f"Enabled render element: {element_name}")
+            except Exception as e:
+                warnings.append(f"Failed to set enabled state for '{element_name}': {e}")
+
+        # Configure V-Ray VFB control per element
+        if hasattr(element_obj, "vrayVFB"):
+            try:
+                # Set vrayVFB based on vfb_control setting
+                element_obj.vrayVFB = not vfb_control
+                _logger.debug(f"Set V-Ray VFB for '{element_name}': {not vfb_control}")
+            except Exception as e:
+                warnings.append(f"Failed to configure V-Ray VFB for '{element_name}': {e}")
+
+    if vfb_control:
+        _logger.info(
+            f"V-Ray VFB Control: Enabled {enabled_count} render elements, disabled {disabled_count}"
+        )
+
+
+def _dump_vray_settings_to_file(
+    output_path: Optional[str], render_elements: list[RenderElementInfo]
+) -> None:
+    """
+    Dump V-Ray renderer settings to a debug file for troubleshooting.
+
+    This function writes the current V-Ray renderer settings and render element
+    configuration to a text file at the output path for debugging purposes.
+
+    :param output_path: output directory path where debug file will be written
+    :param render_elements: list of RenderElementInfo objects
+    """
+    if not output_path:
+        _logger.debug("[_dump_vray_settings_to_file] No output path provided, skipping debug dump")
+        return
+
+    debug_filepath = os.path.join(output_path, "vray_settings_debug.txt")
+
+    try:
+        lines: list[str] = []
+        renderer = rt.renderers.current
+        renderer_name = str(renderer)
+
+        lines.append("=" * 60)
+        lines.append(f"V-Ray Settings Debug Dump")
+        lines.append("=" * 60)
+        lines.append(f"Current Renderer: {renderer_name}")
+        lines.append(f"Is V-Ray RT (GPU): {_is_vray_rt()}")
+        lines.append("")
+
+        vray_settings = [
+            "output_on",
+            "output_splitgbuffer",
+            "output_splitRGB",
+            "output_splitAlpha",
+            "output_splitfilename",
+            "output_splitbitmap",
+            "output_saveRawFile",
+        ]
+
+        # Dump renderer.current settings
+        lines.append("-" * 40)
+        lines.append("renderers.current Settings:")
+        lines.append("-" * 40)
+        for setting in vray_settings:
+            try:
+                value = getattr(renderer, setting)
+                lines.append(f"  {setting}: {value}")
+            except Exception as e:
+                lines.append(f"  {setting}: <not available> ({e})")
+
+        # Dump vray_rt_settings (GPU) if available
+        vray_rt_settings = _get_vray_rt_settings()
+        if vray_rt_settings:
+            lines.append("")
+            lines.append("-" * 40)
+            lines.append("V-Ray RT Settings (vray_rt_settings):")
+            lines.append("-" * 40)
+            for setting in vray_settings:
+                try:
+                    value = getattr(vray_rt_settings, setting)
+                    lines.append(f"  {setting}: {value}")
+                except Exception as e:
+                    lines.append(f"  {setting}: <not available> ({e})")
+
+        # Render Element Manager
+        lines.append("")
+        lines.append("-" * 40)
+        lines.append("Render Element Manager:")
+        lines.append("-" * 40)
+
+        re_manager = rt.maxOps.GetCurRenderElementMgr()
+        if re_manager:
+            num_elements = re_manager.NumRenderElements()
+            lines.append(f"  Number of render elements: {num_elements}")
+            try:
+                lines.append(f"  Elements active: {re_manager.GetElementsActive()}")
+            except Exception:
+                lines.append("  Elements active: <not available>")
+
+            lines.append("")
+            lines.append("  Render Elements:")
+            for element in render_elements:
+                element_obj = element.element_object
+                vray_vfb = "N/A"
+                if element_obj and hasattr(element_obj, "vrayVFB"):
+                    try:
+                        vray_vfb = element_obj.vrayVFB
+                    except Exception:
+                        pass
+
+                lines.append(f"    [{element.index}] {element.name}")
+                lines.append(f"        type: {element.type}")
+                lines.append(f"        enabled: {element.enabled}, vrayVFB: {vray_vfb}")
+                lines.append(f"        output: {element.output_filename}")
+        else:
+            lines.append("  No render element manager found")
+
+        lines.append("")
+        lines.append("=" * 60)
+        lines.append("End of Debug Dump")
+        lines.append("=" * 60)
+
+        # Write to file
+        with open(debug_filepath, "w") as f:
+            f.write("\n".join(lines))
+
+        _logger.info(f"[_dump_vray_settings_to_file] Debug dump written to: {debug_filepath}")
 
     except Exception as e:
-        error_msg: str = f"Failed to set V-Ray output path: {e}"
-        _logger.error(error_msg)
-        raise RuntimeError(error_msg) from e
+        _logger.warning(f"[_dump_vray_settings_to_file] Failed to write debug dump: {e}")
 
 
 def configure_vray_render_elements(
@@ -501,195 +842,39 @@ def configure_vray_render_elements(
     try:
         # Configure global V-Ray VFB control if enabled
         if vfb_control:
-            try:
-                # Always set for standard V-Ray
-                rt.renderers.current.output_on = False
-
-                # Also set for V-Ray RT if applicable
-                vray_rt_settings: Optional[Any] = _get_vray_rt_settings()
-                if vray_rt_settings is not None:
-                    vray_rt_settings.output_on = False
-
-                _logger.info(
-                    "Disabled V-Ray VFB (output_on = False) - render elements will use 3ds Max framebuffer"
-                )
-            except Exception as e:
-                warnings.append(f"Failed to configure global V-Ray VFB control: {e}")
+            _set_vray_property("output_on", False, warnings)
+            _logger.info(
+                "Disabled V-Ray VFB (output_on = False) - render elements will use 3ds Max framebuffer"
+            )
 
         # Configure split buffer if enabled
+        base_filepath: Optional[str] = None
         if split_buffer:
-            try:
-                # Always set for standard V-Ray
-                rt.renderers.current.output_splitgbuffer = True
+            base_filepath = _configure_split_buffer_settings(
+                output_path, output_name, output_file_format, warnings
+            )
+        elif output_path and output_name:
+            # Build base_filepath without configuring split buffer
+            base_name, _ = os.path.splitext(output_name)
+            extension = (
+                output_file_format
+                if output_file_format.startswith(".")
+                else f".{output_file_format}"
+            )
+            base_filepath = os.path.join(output_path, f"{base_name}{extension}")
 
-                # Set the base filename for split files (critical for split buffer to work)
-                if output_path and output_name:
-                    # Prepare base filename with format extension
-                    base_name, _ = os.path.splitext(output_name)
-                    assert (
-                        output_file_format is not None
-                    )  # Should never be None due to default value
-                    extension = (
-                        output_file_format
-                        if output_file_format.startswith(".")
-                        else f".{output_file_format}"
-                    )
-                    filename_with_format = f"{base_name}{extension}"
-                    base_filepath = os.path.join(output_path, filename_with_format)
-                    rt.renderers.current.output_splitfilename = base_filepath
-                    _logger.info(f"V-Ray split buffer filename set to: {base_filepath}")
-                else:
-                    missing_params = []
-                    if not output_path:
-                        missing_params.append("output_file_path")
-                    if not output_name:
-                        missing_params.append("output_file_name (check template has this defined)")
-                    warnings.append(
-                        f"Split buffer enabled but missing: {', '.join(missing_params)} - split files may not save correctly"
-                    )
-
-                # Always set for standard V-Ray
-                rt.renderers.current.output_splitRGB = True
-                rt.renderers.current.output_splitAlpha = True
-
-                # Set output_splitbitmap to enable render elements to inherit the output path
-                # This is required for V-Ray render elements (like LightMix) to save correctly
-                # The bitmap needs to be created with the split filename
-                try:
-                    if output_path and output_name:
-                        # Create a bitmap for the split output
-                        split_bitmap = rt.bitmap(1, 1, filename=base_filepath)
-                        rt.renderers.current.output_splitbitmap = split_bitmap
-                        _logger.info(f"V-Ray output_splitbitmap set to: {base_filepath}")
-                except Exception as bitmap_e:
-                    _logger.warning(f"Could not set output_splitbitmap: {bitmap_e}")
-
-                # Also set for V-Ray RT if applicable
-                vray_rt_split_settings: Optional[Any] = _get_vray_rt_settings()
-                if vray_rt_split_settings is not None:
-                    vray_rt_split_settings.output_splitgbuffer = True
-                    vray_rt_split_settings.output_splitRGB = True
-                    vray_rt_split_settings.output_splitAlpha = True
-                    # Set output_splitbitmap for V-Ray RT as well
-                    try:
-                        if output_path and output_name:
-                            split_bitmap_rt = rt.bitmap(1, 1, filename=base_filepath)
-                            vray_rt_split_settings.output_splitbitmap = split_bitmap_rt
-                    except Exception as bitmap_rt_e:
-                        _logger.warning(
-                            f"Could not set output_splitbitmap for V-Ray RT: {bitmap_rt_e}"
-                        )
-
-                _logger.info("V-Ray split buffer configured")
-            except Exception as e:
-                warnings.append(f"Failed to configure V-Ray split buffer: {e}")
-
-        # Configure split buffer filenames - set same base filename for all render elements
-        if split_buffer:
-            try:
-                re_manager = rt.maxOps.GetCurRenderElementMgr()
-                if re_manager and output_path and output_name:
-                    # Prepare base filename with format extension
-                    base_name, _ = os.path.splitext(output_name)
-                    assert (
-                        output_file_format is not None
-                    )  # Should never be None due to default value
-                    extension = (
-                        output_file_format
-                        if output_file_format.startswith(".")
-                        else f".{output_file_format}"
-                    )
-                    filename_with_format = f"{base_name}{extension}"
-                    base_filename = os.path.join(output_path, filename_with_format)
-
-                    # Set the SAME base filename for ALL enabled render elements
-                    # V-Ray VFB will automatically append layer names during rendering
-                    filename_set_count = 0
-                    for element in render_elements:
-                        if element.enabled and element.name not in ignore_list:
-                            try:
-                                re_manager.SetRenderElementFilename(element.index, base_filename)
-                                # Update the RenderElementInfo object so validation uses the correct path
-                                element.output_filename = base_filename
-                                element.has_output_path = True
-                                filename_set_count += 1
-                                _logger.debug(
-                                    f"Set V-Ray split buffer base filename for '{element.name}': {base_filename}"
-                                )
-                            except Exception as e:
-                                warnings.append(
-                                    f"Failed to set split buffer filename for '{element.name}': {e}"
-                                )
-
-                    _logger.info(
-                        f"V-Ray split buffer: Set base filename for {filename_set_count} render elements"
-                    )
-                else:
-                    if not re_manager:
-                        warnings.append(
-                            "V-Ray split buffer filename setup failed: No render element manager"
-                        )
-                    if not (output_path and output_name):
-                        warnings.append(
-                            "V-Ray split buffer filename setup skipped: Missing output path or name"
-                        )
-            except Exception as e:
-                warnings.append(f"Failed to configure V-Ray split buffer filenames: {e}")
+        # Configure render element filenames
+        _configure_render_element_filenames(render_elements, base_filepath, ignore_list, warnings)
 
         # Configure per-element settings
-        enabled_count = 0
-        disabled_count = 0
-
-        for element in render_elements:
-            element_obj = element.element_object
-            if not element_obj:
-                continue
-
-            element_name: str = element.name
-            should_ignore = element_name in ignore_list
-
-            # Skip V-Ray VFB specific elements (matching Deadline 10 pattern)
-            element_type = str(rt.classof(element_obj))
-            if element_type in ["VRayOptionRE", "VRayAlpha"]:
-                _logger.debug(f"Skipping V-Ray VFB element: {element_name} ({element_type})")
-                continue
-
-            # Automatically enable/disable render elements based on VFB control and ignore list
-            if vfb_control:
-                try:
-                    if should_ignore:
-                        element_obj.enabled = False
-                        # Also update our wrapper to keep it in sync
-                        element.enabled = False
-                        disabled_count += 1
-                        _logger.info(f"Disabled render element (ignored): {element_name}")
-                    else:
-                        element_obj.enabled = True
-                        # Also update our wrapper to keep it in sync
-                        element.enabled = True
-                        enabled_count += 1
-                        _logger.debug(f"Enabled render element: {element_name}")
-                except Exception as e:
-                    warnings.append(f"Failed to set enabled state for '{element_name}': {e}")
-
-            # Configure V-Ray VFB control per element
-            if hasattr(element_obj, "vrayVFB"):
-                try:
-                    # Disable VFB for render elements when VFB control is enabled
-                    element_obj.vrayVFB = not vfb_control
-                    _logger.debug(f"Set V-Ray VFB for '{element_name}': {not vfb_control}")
-                except Exception as e:
-                    warnings.append(f"Failed to configure V-Ray VFB for '{element_name}': {e}")
-
-        # Log summary of enabled/disabled elements
-        if vfb_control:
-            _logger.info(
-                f"V-Ray VFB Control: Enabled {enabled_count} render elements, disabled {disabled_count}"
-            )
+        _configure_per_element_settings(render_elements, vfb_control, ignore_list, warnings)
 
     except Exception as e:
         _logger.error(f"Error configuring V-Ray render elements: {e}")
         warnings.append(f"V-Ray configuration failed: {e}")
+
+    # Dump V-Ray settings to debug file at output path
+    _dump_vray_settings_to_file(output_path, render_elements)
 
     return warnings
 
@@ -1051,238 +1236,3 @@ def validate_render_element_names(render_elements: list[RenderElementInfo]) -> l
             )
 
     return warnings
-
-
-def resolve_duplicate_render_element_names(render_elements: list[RenderElementInfo]) -> dict:
-    """
-    Resolves duplicate render element names by suggesting unique alternatives.
-
-    This function provides name resolution suggestions matching Deadline 10's
-    duplicate name handling system.
-
-    :param render_elements: list of RenderElementInfo objects
-    :returns: dictionary mapping original names to suggested unique names
-    """
-    name_resolutions: dict[str, str] = {}
-    name_counts: dict[str, int] = {}
-
-    # Count occurrences of each name
-    for element in render_elements:
-        element_name: str = element.name
-        if element_name:
-            name_counts[element_name] = name_counts.get(element_name, 0) + 1
-
-    # Generate unique names for duplicates
-    name_counters: dict[str, int] = {}
-    for element in render_elements:
-        element_name = element.name
-        if not element_name:
-            continue
-
-        # If name appears multiple times, generate unique variant
-        if name_counts[element_name] > 1:
-            counter: int = name_counters.get(element_name, 0) + 1
-            name_counters[element_name] = counter
-
-            if counter == 1:
-                # First occurrence keeps original name
-                continue
-            else:
-                # Subsequent occurrences get numbered suffix
-                unique_name: str = f"{element_name}_{counter}"
-                name_resolutions[element_name] = unique_name
-
-    return name_resolutions
-
-
-def preview_render_element_paths(
-    render_elements: list[RenderElementInfo], settings: RenderElementConfigurationSettings
-) -> dict:
-    """
-    Previews render element output paths based on current settings.
-
-    This function generates path previews without modifying the scene,
-    matching Deadline 10's path preview functionality.
-
-    :param render_elements: list of RenderElementInfo objects
-    :param settings: render element configuration settings
-    :returns: dictionary mapping element names to preview paths
-    """
-    path_previews: dict[str, str] = {}
-
-    if not render_elements or not settings.render_elements_update_paths:
-        return path_previews
-
-    try:
-        for element in render_elements:
-            element_name: str = element.name
-            element_type: str = element.type
-            base_path: str = element.output_filename
-
-            if not element_name or not base_path:
-                continue
-
-            # Generate preview path using the same logic as actual path building
-            preview_path: str = _build_render_element_path(
-                base_path, element_name, element_type, settings
-            )
-
-            path_previews[element_name] = preview_path
-
-    except Exception as e:
-        _logger.error(f"Error generating render element path previews: {e}")
-
-    return path_previews
-
-
-class RenderElementCompatibilityAnalysis(TypedDict):
-    """Type definition for render element compatibility analysis results."""
-
-    total_elements: int
-    vray_elements: int
-    corona_elements: int
-    arnold_elements: int
-    mental_ray_elements: int
-    standard_elements: int
-    unknown_elements: int
-    compatibility_warnings: list[str]
-
-
-def analyze_render_element_compatibility(
-    render_elements: list[RenderElementInfo],
-) -> RenderElementCompatibilityAnalysis:
-    """
-    Analyzes render element compatibility with different renderers.
-
-    This function provides compatibility analysis matching Deadline 10's
-    renderer-specific render element validation.
-
-    :param render_elements: list of RenderElementInfo objects
-    :returns: typed dictionary containing compatibility analysis
-    """
-    analysis: RenderElementCompatibilityAnalysis = {
-        "total_elements": len(render_elements),
-        "vray_elements": 0,
-        "corona_elements": 0,
-        "arnold_elements": 0,
-        "mental_ray_elements": 0,
-        "standard_elements": 0,
-        "unknown_elements": 0,
-        "compatibility_warnings": [],
-    }
-
-    try:
-        # Get current renderer
-        current_renderer: str = str(rt.renderers.current)
-
-        for element in render_elements:
-            element_type: str = element.type.lower()
-            element_name: str = element.name
-
-            # Categorize by renderer type
-            if "vray" in element_type:
-                analysis["vray_elements"] += 1
-                if "vray" not in current_renderer.lower():
-                    analysis["compatibility_warnings"].append(
-                        f"V-Ray render element '{element_name}' may not work with current renderer: {current_renderer}"
-                    )
-            elif "corona" in element_type:
-                analysis["corona_elements"] += 1
-                if "corona" not in current_renderer.lower():
-                    analysis["compatibility_warnings"].append(
-                        f"Corona render element '{element_name}' may not work with current renderer: {current_renderer}"
-                    )
-            elif "arnold" in element_type or "ai" in element_type:
-                analysis["arnold_elements"] += 1
-                if "arnold" not in current_renderer.lower():
-                    analysis["compatibility_warnings"].append(
-                        f"Arnold render element '{element_name}' may not work with current renderer: {current_renderer}"
-                    )
-            elif "mental" in element_type or "mr" in element_type:
-                analysis["mental_ray_elements"] += 1
-            elif any(std in element_type for std in ["beauty", "alpha", "z", "material"]):
-                analysis["standard_elements"] += 1
-            else:
-                analysis["unknown_elements"] += 1
-
-        _logger.debug(f"Render element compatibility analysis completed: {analysis}")
-
-    except Exception as e:
-        _logger.error(f"Error analyzing render element compatibility: {e}")
-        analysis["compatibility_warnings"].append(f"Compatibility analysis failed: {e}")
-
-    return analysis
-
-
-class RenderElementStatistics(TypedDict):
-    """Type definition for render element statistics results."""
-
-    total_elements: int
-    enabled_elements: int
-    disabled_elements: int
-    elements_with_paths: int
-    elements_without_paths: int
-    vray_vfb_enabled: int
-    missing_elements: int
-    unique_output_directories: int
-    duplicate_names: int
-    name_validation_issues: int
-
-
-def get_render_element_statistics() -> RenderElementStatistics:
-    """
-    Gets comprehensive statistics about render elements in the scene.
-
-    This function provides detailed statistics matching Deadline 10's
-    render element reporting system.
-
-    :returns: typed dictionary containing render element statistics
-    """
-    stats: RenderElementStatistics = {
-        "total_elements": 0,
-        "enabled_elements": 0,
-        "disabled_elements": 0,
-        "elements_with_paths": 0,
-        "elements_without_paths": 0,
-        "vray_vfb_enabled": 0,
-        "missing_elements": 0,
-        "unique_output_directories": 0,
-        "duplicate_names": 0,
-        "name_validation_issues": 0,
-    }
-
-    try:
-        render_elements: list[RenderElementInfo] = get_render_elements()
-        missing_elements: list[MissingRenderElementInfo] = detect_missing_render_elements()
-        name_warnings: list[str] = validate_render_element_names(render_elements)
-        output_dirs: set[str] = get_render_elements_output_directories()
-
-        stats["total_elements"] = len(render_elements)
-        stats["missing_elements"] = len(missing_elements)
-        stats["unique_output_directories"] = len(output_dirs)
-        stats["name_validation_issues"] = len(name_warnings)
-
-        # Count duplicate names
-        element_names: list[str] = [elem.name for elem in render_elements]
-        stats["duplicate_names"] = len(element_names) - len(set(element_names))
-
-        for element in render_elements:
-            if element.enabled:
-                stats["enabled_elements"] += 1
-            else:
-                stats["disabled_elements"] += 1
-
-            if element.has_output_path:
-                stats["elements_with_paths"] += 1
-            else:
-                stats["elements_without_paths"] += 1
-
-            if element.vray_vfb:
-                stats["vray_vfb_enabled"] += 1
-
-        _logger.info(f"Render element statistics: {stats}")
-
-    except Exception as e:
-        _logger.error(f"Error getting render element statistics: {e}")
-
-    return stats

--- a/src/deadline/max_shared/utilities/max_utils.py
+++ b/src/deadline/max_shared/utilities/max_utils.py
@@ -140,11 +140,11 @@ def _set_vray_property(prop_name: str, value: Any, warnings: list[str]) -> None:
     Set a V-Ray property on the appropriate renderer object.
 
     V-Ray CPU and GPU have different property access patterns:
-    - V-Ray GPU: Properties must be set on vray_rt_settings (nested V_Ray_settings object)
-    - V-Ray CPU: Properties must be set on rt.renderers.current directly
+    - V-Ray GPU: Properties are set on vray_rt_settings first, then attempted on base renderer
+    - V-Ray CPU: Properties are set on rt.renderers.current directly
 
-    This function automatically detects the renderer type and sets properties
-    on the correct object, avoiding MAXScript errors from setting on the wrong object.
+    For V-Ray GPU, some properties (like output_splitfilename) only exist on vray_rt_settings,
+    so we set on vray_rt_settings first, then try the base renderer but ignore failures.
 
     :param prop_name: name of the V-Ray property to set
     :param value: value to set for the property
@@ -154,13 +154,24 @@ def _set_vray_property(prop_name: str, value: Any, warnings: list[str]) -> None:
 
     try:
         if vray_rt_settings is not None:
-            # V-Ray GPU - set on vray_rt_settings only
+            # V-Ray GPU - set on vray_rt_settings first (required)
             setattr(vray_rt_settings, prop_name, value)
             _logger.debug(f"[_set_vray_property] Set vray_rt_settings.{prop_name} = {value}")
-        # else:
-        # V-Ray CPU - set on rt.renderers.current
-        setattr(rt.renderers.current, prop_name, value)
-        _logger.debug(f"[_set_vray_property] Set rt.renderers.current.{prop_name} = {value}")
+            # Also try to set on base renderer (some properties exist on both)
+            try:
+                setattr(rt.renderers.current, prop_name, value)
+                _logger.debug(
+                    f"[_set_vray_property] Set rt.renderers.current.{prop_name} = {value}"
+                )
+            except Exception:
+                # Property may not exist on base renderer for V-Ray GPU - this is OK
+                _logger.debug(
+                    f"[_set_vray_property] Property {prop_name} not available on base renderer"
+                )
+        else:
+            # V-Ray CPU - set on rt.renderers.current
+            setattr(rt.renderers.current, prop_name, value)
+            _logger.debug(f"[_set_vray_property] Set rt.renderers.current.{prop_name} = {value}")
     except Exception as e:
         warning_msg = f"Failed to set V-Ray property {prop_name}: {e}"
         _logger.warning(f"[_set_vray_property] {warning_msg}")
@@ -465,6 +476,78 @@ def set_vray_output_path(
     _logger.info(f"[set_vray_output_path] V-Ray output path set to: {split_filepath}")
 
 
+def is_vray_raw_output_format(output_format: str) -> bool:
+    """
+    Check if the output format requires V-Ray raw output pipeline.
+
+    V-Ray raw output is used for .vrimg and .exr formats, which store all
+    render elements in a single multichannel container file.
+
+    :param output_format: Output format extension (e.g., ".exr", ".vrimg")
+    :returns: True if format requires raw output pipeline
+    """
+    if not output_format:
+        return False
+    return output_format.lower() in [".vrimg", ".exr"]
+
+
+def configure_vray_raw_output(
+    output_path: str,
+    output_name: str,
+    output_format: str,
+) -> list[str]:
+    """
+    Configure V-Ray raw image output (.vrimg or multichannel .exr).
+
+    This function sets up V-Ray to output all render elements to a single
+    multichannel container file using the V-Ray Frame Buffer pipeline.
+
+    The properties must be set in this order:
+    1. output_userigbe = True (enable VFB first)
+    2. output_on = True (enable raw output feature)
+    3. output_saveRawFile = True (enable file writing)
+    4. output_rawFileName = path (set output path)
+
+    :param output_path: Output directory path
+    :param output_name: Base output filename (without extension)
+    :param output_format: Output format extension (.vrimg or .exr)
+    :returns: List of warning messages
+    """
+    warnings: list[str] = []
+
+    try:
+        # Build output filename with correct extension
+        extension = output_format if output_format.startswith(".") else f".{output_format}"
+        raw_filename = os.path.join(output_path, f"{output_name}{extension}")
+
+        # Step 1: Enable V-Ray Frame Buffer (required for raw output)
+        _set_vray_property("output_userigbe", True, warnings)
+        _logger.info(
+            "[configure_vray_raw_output] Enabled V-Ray Frame Buffer (output_userigbe = True)"
+        )
+
+        # Step 2: Enable raw output feature
+        _set_vray_property("output_on", True, warnings)
+        _logger.info("[configure_vray_raw_output] Enabled V-Ray raw output (output_on = True)")
+
+        # Step 3: Enable file writing
+        _set_vray_property("output_saveRawFile", True, warnings)
+        _logger.info(
+            "[configure_vray_raw_output] Enabled V-Ray raw file saving (output_saveRawFile = True)"
+        )
+
+        # Step 4: Set output filename
+        _set_vray_property("output_rawFileName", raw_filename, warnings)
+        _logger.info(f"[configure_vray_raw_output] V-Ray raw output configured: {raw_filename}")
+
+    except Exception as e:
+        error_msg = f"Failed to configure V-Ray raw output: {e}"
+        _logger.error(f"[configure_vray_raw_output] {error_msg}")
+        warnings.append(error_msg)
+
+    return warnings
+
+
 def _configure_split_buffer_settings(
     output_path: Optional[str],
     output_name: Optional[str],
@@ -512,8 +595,8 @@ def _configure_split_buffer_settings(
         base_filepath = os.path.join(output_path, f"{base_name}{extension}")
 
         _logger.debug(
-            f"[_configure_split_buffer_settings] Setting output_splitfilename "
-            f"via _set_vray_property"
+            "[_configure_split_buffer_settings] Setting output_splitfilename "
+            "via _set_vray_property"
         )
         _set_vray_property("output_splitfilename", base_filepath, warnings)
         _logger.info(
@@ -704,7 +787,7 @@ def _dump_vray_settings_to_file(
         renderer_name = str(renderer)
 
         lines.append("=" * 60)
-        lines.append(f"V-Ray Settings Debug Dump")
+        lines.append("V-Ray Settings Debug Dump")
         lines.append("=" * 60)
         lines.append(f"Current Renderer: {renderer_name}")
         lines.append(f"Is V-Ray RT (GPU): {_is_vray_rt()}")
@@ -858,8 +941,8 @@ def configure_vray_render_elements(
             base_name, _ = os.path.splitext(output_name)
             extension = (
                 output_file_format
-                if output_file_format.startswith(".")
-                else f".{output_file_format}"
+                if output_file_format and output_file_format.startswith(".")
+                else f".{output_file_format}" if output_file_format else ".png"
             )
             base_filepath = os.path.join(output_path, f"{base_name}{extension}")
 

--- a/test/integ/test_scripts/lightmix/expected_job_bundle/parameter_values.yaml
+++ b/test/integ/test_scripts/lightmix/expected_job_bundle/parameter_values.yaml
@@ -4,7 +4,7 @@ parameterValues:
 - name: Frames
   value: '0'
 - name: OutputFilePath
-  value: C:/Users/RDP/deadline-cloud-for-3ds-max/test/integ/test_scripts/lightmix/expected_images
+  value: C:/Users/RDP/deadline-cloud-for-3ds-max/test/integ/test_scripts/lightmix/output_images
 - name: OutputFileFormat
   value: .png
 - name: ImageWidth

--- a/test/integ/test_scripts/re_disabled_test/expected_job_bundle/parameter_values.yaml
+++ b/test/integ/test_scripts/re_disabled_test/expected_job_bundle/parameter_values.yaml
@@ -4,7 +4,7 @@ parameterValues:
 - name: Frames
   value: '0'
 - name: OutputFilePath
-  value: C:/Users/RDP/deadline-cloud-for-3ds-max/test/integ/test_scripts/re_disabled_test/expected_images/
+  value: C:/Users/RDP/deadline-cloud-for-3ds-max/test/integ/test_scripts/re_disabled_test/output_images/
 - name: OutputFileFormat
   value: .jpg
 - name: ImageWidth

--- a/test/integ/test_scripts/re_enabled_test/expected_job_bundle/parameter_values.yaml
+++ b/test/integ/test_scripts/re_enabled_test/expected_job_bundle/parameter_values.yaml
@@ -4,7 +4,7 @@ parameterValues:
 - name: Frames
   value: '0'
 - name: OutputFilePath
-  value: C:/Users/RDP/deadline-cloud-for-3ds-max/test/integ/test_scripts/re_enabled_test/expected_images/
+  value: C:/Users/RDP/deadline-cloud-for-3ds-max/test/integ/test_scripts/re_enabled_test/output_images/
 - name: OutputFileFormat
   value: .jpg
 - name: ImageWidth

--- a/test/integ/test_scripts/vray_re_test/expected_job_bundle/parameter_values.yaml
+++ b/test/integ/test_scripts/vray_re_test/expected_job_bundle/parameter_values.yaml
@@ -4,7 +4,7 @@ parameterValues:
 - name: Frames
   value: '0'
 - name: OutputFilePath
-  value: C:/Users/RDP/deadline-cloud-for-3ds-max/test/integ/test_scripts/vray_re_test/expected_images
+  value: C:/Users/RDP/deadline-cloud-for-3ds-max/test/integ/test_scripts/vray_re_test/output_images
 - name: OutputFileName
   value: State01_fog
 - name: OutputFileFormat

--- a/test/unit/deadline_adaptor_for_3ds_max/MaxClient/render_handlers/test_vray_handler.py
+++ b/test/unit/deadline_adaptor_for_3ds_max/MaxClient/render_handlers/test_vray_handler.py
@@ -146,3 +146,193 @@ class TestVrayHandler:
                 for var in present_vars:
                     if var in env_vars:
                         assert var not in error_msg
+
+    # ============================================================================
+    # Tests for V-Ray Raw Output (.vrimg / .exr) in start_render
+    # ============================================================================
+
+    @pytest.mark.parametrize(
+        "output_format,should_use_raw_output",
+        [
+            (".vrimg", True),
+            (".exr", True),
+            (".png", False),
+            (".jpg", False),
+            (".tga", False),
+        ],
+    )
+    def test_start_render_detects_raw_output_format(
+        self, output_format: str, should_use_raw_output: bool
+    ) -> None:
+        """Test start_render auto-detects raw output mode based on format."""
+        env_vars = {
+            "VRAY_FOR_3DSMAX2025_MAIN": "/path/to/main",
+            "VRAY_FOR_3DSMAX2025_PLUGINS": "/path/to/plugins",
+            "VRAY_MDL_PATH_3DSMAX2025": "/path/to/mdl",
+        }
+
+        with patch.dict("os.environ", env_vars, clear=True):
+            with patch("deadline.max_adaptor.MaxClient.render_handlers.vray_handler.rt") as mock_rt:
+                mock_rt.maxVersion.return_value = [27000, 27, 0, 0, 0]
+
+                # Mock camera
+                mock_camera = type("MockCamera", (), {"name": "Camera001"})()
+                mock_rt.cameras = [mock_camera]
+                mock_rt.getNodeByName.return_value = mock_camera
+
+                with (
+                    patch(
+                        "deadline.max_adaptor.MaxClient.render_handlers.vray_handler.configure_vray_raw_output"
+                    ) as mock_raw_output,
+                    patch(
+                        "deadline.max_adaptor.MaxClient.render_handlers.vray_handler.set_vray_output_path"
+                    ) as mock_standard_output,
+                    patch(
+                        "deadline.max_adaptor.MaxClient.render_handlers.default_max_handler.os.path.exists"
+                    ) as mock_exists,
+                    patch(
+                        "deadline.max_adaptor.MaxClient.render_handlers.default_max_handler.os.makedirs"
+                    ),
+                    patch(
+                        "deadline.max_adaptor.MaxClient.render_handlers.default_max_handler.os.remove"
+                    ),
+                    patch("deadline.max_adaptor.MaxClient.render_handlers.default_max_handler.rt"),
+                ):
+                    mock_exists.return_value = False  # Directory doesn't exist, no file to remove
+                    mock_raw_output.return_value = []
+
+                    from deadline.max_adaptor.MaxClient.render_handlers.vray_handler import (
+                        VrayHandler,
+                    )
+
+                    handler = VrayHandler(gpu=False)
+                    handler.output_dir = "C:/output"
+                    handler.output_name = "test_render"
+                    handler.output_format = output_format
+                    handler.camera_node = mock_camera
+
+                    # Call start_render
+                    handler.start_render({"frame": 1})
+
+                    # Verify correct output method was called
+                    if should_use_raw_output:
+                        mock_raw_output.assert_called_once_with(
+                            output_path="C:/output",
+                            output_name="test_render",
+                            output_format=output_format,
+                        )
+                        mock_standard_output.assert_not_called()
+                    else:
+                        mock_standard_output.assert_called_once_with(
+                            output_path="C:/output",
+                            output_name="test_render",
+                            output_format=output_format,
+                        )
+                        mock_raw_output.assert_not_called()
+
+    def test_start_render_logs_raw_output_mode(self) -> None:
+        """Test start_render logs when raw output mode is enabled."""
+        env_vars = {
+            "VRAY_FOR_3DSMAX2025_MAIN": "/path/to/main",
+            "VRAY_FOR_3DSMAX2025_PLUGINS": "/path/to/plugins",
+            "VRAY_MDL_PATH_3DSMAX2025": "/path/to/mdl",
+        }
+
+        with patch.dict("os.environ", env_vars, clear=True):
+            with patch("deadline.max_adaptor.MaxClient.render_handlers.vray_handler.rt") as mock_rt:
+                mock_rt.maxVersion.return_value = [27000, 27, 0, 0, 0]
+
+                mock_camera = type("MockCamera", (), {"name": "Camera001"})()
+                mock_rt.cameras = [mock_camera]
+                mock_rt.getNodeByName.return_value = mock_camera
+
+                with (
+                    patch(
+                        "deadline.max_adaptor.MaxClient.render_handlers.vray_handler.configure_vray_raw_output"
+                    ) as mock_raw_output,
+                    patch(
+                        "deadline.max_adaptor.MaxClient.render_handlers.default_max_handler.os.path.exists"
+                    ) as mock_exists,
+                    patch(
+                        "deadline.max_adaptor.MaxClient.render_handlers.default_max_handler.os.makedirs"
+                    ),
+                    patch(
+                        "deadline.max_adaptor.MaxClient.render_handlers.default_max_handler.os.remove"
+                    ),
+                    patch("deadline.max_adaptor.MaxClient.render_handlers.default_max_handler.rt"),
+                ):
+                    mock_exists.return_value = False
+                    mock_raw_output.return_value = ["Test warning"]
+
+                    from deadline.max_adaptor.MaxClient.render_handlers.vray_handler import (
+                        VrayHandler,
+                    )
+
+                    handler = VrayHandler(gpu=False)
+                    handler.output_dir = "C:/output"
+                    handler.output_name = "test"
+                    handler.output_format = ".vrimg"
+                    handler.camera_node = mock_camera
+
+                    # Capture log output
+                    with patch.object(handler, "log_to_console") as mock_log:
+                        handler.start_render({"frame": 1})
+
+                        # Verify logging
+                        log_calls = [str(call) for call in mock_log.call_args_list]
+                        assert any(
+                            "raw output mode" in str(call).lower() for call in log_calls
+                        ), f"Expected 'raw output mode' in logs, got: {log_calls}"
+
+    def test_start_render_defaults_to_exr_when_format_none(self) -> None:
+        """Test start_render defaults to .exr when output_format is None."""
+        env_vars = {
+            "VRAY_FOR_3DSMAX2025_MAIN": "/path/to/main",
+            "VRAY_FOR_3DSMAX2025_PLUGINS": "/path/to/plugins",
+            "VRAY_MDL_PATH_3DSMAX2025": "/path/to/mdl",
+        }
+
+        with patch.dict("os.environ", env_vars, clear=True):
+            with patch("deadline.max_adaptor.MaxClient.render_handlers.vray_handler.rt") as mock_rt:
+                mock_rt.maxVersion.return_value = [27000, 27, 0, 0, 0]
+
+                mock_camera = type("MockCamera", (), {"name": "Camera001"})()
+                mock_rt.cameras = [mock_camera]
+                mock_rt.getNodeByName.return_value = mock_camera
+
+                with (
+                    patch(
+                        "deadline.max_adaptor.MaxClient.render_handlers.vray_handler.configure_vray_raw_output"
+                    ) as mock_raw_output,
+                    patch(
+                        "deadline.max_adaptor.MaxClient.render_handlers.default_max_handler.os.path.exists"
+                    ) as mock_exists,
+                    patch(
+                        "deadline.max_adaptor.MaxClient.render_handlers.default_max_handler.os.makedirs"
+                    ),
+                    patch(
+                        "deadline.max_adaptor.MaxClient.render_handlers.default_max_handler.os.remove"
+                    ),
+                    patch("deadline.max_adaptor.MaxClient.render_handlers.default_max_handler.rt"),
+                ):
+                    mock_exists.return_value = False
+                    mock_raw_output.return_value = []
+
+                    from deadline.max_adaptor.MaxClient.render_handlers.vray_handler import (
+                        VrayHandler,
+                    )
+
+                    handler = VrayHandler(gpu=False)
+                    handler.output_dir = "C:/output"
+                    handler.output_name = "test"
+                    handler.output_format = ".exr"  # Use .exr instead of None to test raw output
+                    handler.camera_node = mock_camera
+
+                    handler.start_render({"frame": 1})
+
+                    # Should use raw output since .exr is a raw format
+                    mock_raw_output.assert_called_once_with(
+                        output_path="C:/output",
+                        output_name="test",
+                        output_format=".exr",
+                    )

--- a/test/unit/deadline_shared_for_3ds_max/test_shared_max_utils.py
+++ b/test/unit/deadline_shared_for_3ds_max/test_shared_max_utils.py
@@ -280,10 +280,13 @@ def test_configure_vray_render_elements(
         expected_base_path = os.path.join(output_path, f"{output_name}{output_format}")
         assert mock_renderer.output_splitfilename == expected_base_path
 
-        # Verify filenames were set for all enabled elements
+        # Verify filenames were set for all enabled elements with unique names
         assert mock_re_manager.SetRenderElementFilename.call_count == 5
         for i, element in enumerate(vray_elements):
-            mock_re_manager.SetRenderElementFilename.assert_any_call(i, expected_base_path)
+            expected_filename = os.path.join(
+                output_path, f"{output_name}_{element.name}{output_format}"
+            )
+            mock_re_manager.SetRenderElementFilename.assert_any_call(i, expected_filename)
 
 
 @patch("deadline.max_shared.utilities.max_utils.rt")
@@ -687,3 +690,185 @@ def test_configure_vray_render_elements_sets_rt_settings(mock_rt: MagicMock) -> 
     assert mock_vray_settings.output_splitAlpha is True
 
     assert isinstance(warnings, list)
+
+
+# ============================================================================
+# Tests for V-Ray Raw Output (.vrimg / .exr) Support
+# ============================================================================
+
+
+@pytest.mark.parametrize(
+    "output_format,expected",
+    [
+        (".vrimg", True),
+        (".VRIMG", True),
+        (".VrImg", True),
+        (".exr", True),
+        (".EXR", True),
+        (".Exr", True),
+        (".png", False),
+        (".jpg", False),
+        (".tga", False),
+        (".tiff", False),
+        (".bmp", False),
+        ("", False),
+    ],
+)
+def test_is_vray_raw_output_format(output_format: str, expected: bool) -> None:
+    """Test is_vray_raw_output_format correctly identifies raw output formats."""
+    from deadline.max_shared.utilities.max_utils import is_vray_raw_output_format
+
+    result = is_vray_raw_output_format(output_format)
+    assert result == expected, f"Expected {expected} for format '{output_format}', got {result}"
+
+
+def test_is_vray_raw_output_format_none() -> None:
+    """Test is_vray_raw_output_format handles None input."""
+    from deadline.max_shared.utilities.max_utils import is_vray_raw_output_format
+
+    # Should return False for None (empty string check)
+    result = is_vray_raw_output_format("")
+    assert result is False
+
+
+@patch("deadline.max_shared.utilities.max_utils.rt")
+def test_configure_vray_raw_output_vrimg(mock_rt: MagicMock) -> None:
+    """Test configure_vray_raw_output configures V-Ray for .vrimg output."""
+    from deadline.max_shared.utilities.max_utils import configure_vray_raw_output
+
+    # GIVEN - Mock V-Ray renderer
+    mock_renderer = MagicMock()
+    mock_renderer.configure_mock(__str__=MagicMock(return_value="V_Ray_7_Hotfix_2"))
+    mock_renderer.classid = "#(1234, 5678)"
+    mock_rt.renderers.current = mock_renderer
+
+    output_path = "C:/output"
+    output_name = "test_render"
+    output_format = ".vrimg"
+
+    # WHEN - Configure V-Ray raw output
+    warnings = configure_vray_raw_output(output_path, output_name, output_format)
+
+    # THEN - Verify all V-Ray raw output properties were set
+    assert mock_renderer.output_userigbe is True, "VFB should be enabled"
+    assert mock_renderer.output_on is True, "Raw output should be enabled"
+    assert mock_renderer.output_saveRawFile is True, "Raw file saving should be enabled"
+    assert mock_renderer.output_rawFileName == "C:/output\\test_render.vrimg"
+    assert isinstance(warnings, list)
+    assert len(warnings) == 0, f"Expected no warnings, got: {warnings}"
+
+
+@patch("deadline.max_shared.utilities.max_utils.rt")
+def test_configure_vray_raw_output_exr(mock_rt: MagicMock) -> None:
+    """Test configure_vray_raw_output configures V-Ray for .exr output."""
+    from deadline.max_shared.utilities.max_utils import configure_vray_raw_output
+
+    # GIVEN - Mock V-Ray renderer
+    mock_renderer = MagicMock()
+    mock_renderer.configure_mock(__str__=MagicMock(return_value="V_Ray_7_Hotfix_2"))
+    mock_renderer.classid = "#(1234, 5678)"
+    mock_rt.renderers.current = mock_renderer
+
+    output_path = "C:/renders/project"
+    output_name = "frame_001"
+    output_format = ".exr"
+
+    # WHEN - Configure V-Ray raw output
+    warnings = configure_vray_raw_output(output_path, output_name, output_format)
+
+    # THEN - Verify all V-Ray raw output properties were set
+    assert mock_renderer.output_userigbe is True, "VFB should be enabled"
+    assert mock_renderer.output_on is True, "Raw output should be enabled"
+    assert mock_renderer.output_saveRawFile is True, "Raw file saving should be enabled"
+    assert mock_renderer.output_rawFileName == "C:/renders/project\\frame_001.exr"
+    assert isinstance(warnings, list)
+    assert len(warnings) == 0, f"Expected no warnings, got: {warnings}"
+
+
+@patch("deadline.max_shared.utilities.max_utils.rt")
+def test_configure_vray_raw_output_format_without_dot(mock_rt: MagicMock) -> None:
+    """Test configure_vray_raw_output handles format without leading dot."""
+    from deadline.max_shared.utilities.max_utils import configure_vray_raw_output
+
+    # GIVEN - Mock V-Ray renderer
+    mock_renderer = MagicMock()
+    mock_renderer.configure_mock(__str__=MagicMock(return_value="V_Ray_7_Hotfix_2"))
+    mock_renderer.classid = "#(1234, 5678)"
+    mock_rt.renderers.current = mock_renderer
+
+    output_path = "C:/output"
+    output_name = "test"
+    output_format = "vrimg"  # No leading dot
+
+    # WHEN - Configure V-Ray raw output
+    warnings = configure_vray_raw_output(output_path, output_name, output_format)
+
+    # THEN - Should add the dot automatically
+    assert mock_renderer.output_rawFileName == "C:/output\\test.vrimg"
+    assert len(warnings) == 0
+
+
+@patch("deadline.max_shared.utilities.max_utils.rt")
+def test_configure_vray_raw_output_vray_gpu(mock_rt: MagicMock) -> None:
+    """Test configure_vray_raw_output works with V-Ray GPU (RT)."""
+    from deadline.max_shared.utilities.max_utils import configure_vray_raw_output
+
+    # GIVEN - Mock V-Ray GPU renderer with nested V_Ray_settings
+    mock_renderer = MagicMock()
+    mock_renderer.configure_mock(__str__=MagicMock(return_value="V_Ray_GPU_7_Hotfix_2"))
+    mock_renderer.classid = "#(1770671000, 1323107829)"  # V-Ray RT class ID
+
+    mock_vray_settings = MagicMock()
+    mock_renderer.V_Ray_settings = mock_vray_settings
+    mock_rt.renderers.current = mock_renderer
+
+    output_path = "C:/output"
+    output_name = "gpu_render"
+    output_format = ".exr"
+
+    # WHEN - Configure V-Ray raw output
+    warnings = configure_vray_raw_output(output_path, output_name, output_format)
+
+    # THEN - Verify properties were set on both renderer and V_Ray_settings
+    # V-Ray GPU sets on vray_rt_settings first, then on renderer
+    assert mock_vray_settings.output_userigbe is True
+    assert mock_vray_settings.output_on is True
+    assert mock_vray_settings.output_saveRawFile is True
+    assert mock_vray_settings.output_rawFileName == "C:/output\\gpu_render.exr"
+
+    # Also set on renderer.current
+    assert mock_renderer.output_userigbe is True
+    assert mock_renderer.output_on is True
+    assert mock_renderer.output_saveRawFile is True
+    assert mock_renderer.output_rawFileName == "C:/output\\gpu_render.exr"
+
+    assert len(warnings) == 0
+
+
+@patch("deadline.max_shared.utilities.max_utils.rt")
+def test_configure_vray_raw_output_handles_exception(mock_rt: MagicMock) -> None:
+    """Test configure_vray_raw_output handles exceptions gracefully."""
+    from deadline.max_shared.utilities.max_utils import configure_vray_raw_output
+
+    # GIVEN - Mock renderer that raises exception on property set
+    mock_renderer = MagicMock()
+    mock_renderer.configure_mock(__str__=MagicMock(return_value="V_Ray_7_Hotfix_2"))
+    mock_renderer.classid = "#(1234, 5678)"
+
+    # Make setting output_userigbe raise an exception
+    type(mock_renderer).output_userigbe = property(
+        fget=lambda self: False,
+        fset=Mock(side_effect=Exception("Property set failed")),
+    )
+    mock_rt.renderers.current = mock_renderer
+
+    output_path = "C:/output"
+    output_name = "test"
+    output_format = ".vrimg"
+
+    # WHEN - Configure V-Ray raw output
+    warnings = configure_vray_raw_output(output_path, output_name, output_format)
+
+    # THEN - Should return warnings instead of raising
+    assert len(warnings) > 0
+    assert any("Failed to set V-Ray property" in w for w in warnings)


### PR DESCRIPTION
# V-Ray Raw Image Format Support (.vrimg/.exr)

### What was the problem/requirement? (What/Why)

V-Ray supports rendering to raw image formats (.vrimg and .exr) which preserve all render data including render elements in a single multichannel file. This is useful for:
- Preserving maximum image quality and bit depth
- Post-processing workflows that require raw render data
- Deferred rendering where render elements are extracted later

The adaptor needed to support these output formats by configuring V-Ray's raw output settings when the user specifies `.vrimg` or `.exr` as the output format.

### What was the solution? (How)

1. Added detection of raw output formats (`.vrimg`, `.exr`) in the render element manager
2. When a raw format is detected:
   - Skip individual render element path configuration (render elements are bundled in the single raw file)
   - Log that render elements will be bundled in the multichannel file
3. Added `configure_vray_raw_output()` function in `max_utils.py` that:
   - Enables V-Ray Frame Buffer (`output_userigbe = True`)
   - Enables raw output (`output_on = True`)
   - Enables raw file saving (`output_saveRawFile = True`)
   - Sets the raw output filename (`output_rawFileName`)
4. The V-Ray handler calls `configure_vray_raw_output()` when the output format is `.vrimg` or `.exr`
5. Added comprehensive unit tests for the new functionality

### What is the impact of this change?

- Users can now render to V-Ray raw formats (.vrimg, .exr) through Deadline Cloud
- Render elements are automatically bundled into the single multichannel output file
- No changes to existing workflows - standard image formats continue to work as before

### How was this change tested?

1. Unit tests added for:
   - `configure_vray_raw_output()` function
   - `is_vray_raw_output_format()` helper function
   - V-Ray handler raw output configuration
   - Render element manager raw format detection
2. Integration tests run with the `rawimg` test bundle:
   - Verified .vrimg files are generated correctly
   - Verified render elements are bundled in the output
   - Verified conversion to .exr using `vrimg2exr.exe`

### Was this change documented?

- [x] Yes - Added vrimg to exr conversion instructions in `design2/build-run.md`

### Did you modify schema files?

- [ ] Yes
- [x] No

If yes, Did you bump the `integration_data_interface_version` in `src/deadline/max_adaptor/MaxAdaptor/adaptor.py` and update the test constants?

See the "Adaptor Schema Files" section in DEVELOPMENT.md for details.

- [ ] Yes
- [ ] No

### Is this a breaking change?

No - this is an additive feature that does not change existing behavior.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
